### PR TITLE
Send compressed requests

### DIFF
--- a/realtorca.js
+++ b/realtorca.js
@@ -19,6 +19,7 @@ class Realtor {
 			method: 'POST',
 			uri: API_URL,
 			form: form,
+			gzip: true,
 			json: true
 		});
 	}


### PR DESCRIPTION
Today, requests have been returning `403` errors with `Request unsuccessful. Incapsula incident ID` in the body.  Sending compressed requests fixes it for me.  No idea why 🤷 